### PR TITLE
Feature/reorder convention name

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,10 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+    enabled = true
+    version = "0.40.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,8 @@ terraform {
       version = "~> 6.0"
     }
   }
+  required_version = "~> 1.10.0"
+
 }
 
 provider "aws" {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,13 @@
+locals {
+  naming_prefix = "${var.prefix}-${var.project}-${var.environment}-${var.region}"
+
+  default_tags = {
+    Project      = var.project
+    Environment  = var.environment
+    Organization = var.organization
+  }
+}
+
 terraform {
   required_providers {
     aws = {
@@ -9,28 +19,34 @@ terraform {
 
 provider "aws" {
   region = "us-east-1"
+  default_tags {
+    tags = local.default_tags
+  }
 }
+
 
 
 module "network" {
   source              = "./modules/network"
-  vpc_name            = var.vpc_name
+  naming_prefix         = local.naming_prefix
+  #vpc_name            = var.vpc_name
   public_subnet_cidrs = var.public_subnet_cidrs
   availability_zones  = var.availability_zones
   my_public_ip        = var.my_public_ip
-  organization        = var.organization
+  #organization        = var.organization
 }
 
 module "instance" {
   source            = "./modules/instance"
+  naming_prefix         = local.naming_prefix
   #vpc_id            = module.network.vpc_id
   subnet_id         = module.network.public_subnet_ids[0].id
-  security_group_id = [module.network.security_group_id]
+  security_groups_id = [module.network.security_group_id]
   #key_name          = var.key_name
   public_key        = var.public_key
   ami               = var.ami
   instance_type     = var.instance_type
-  vpc_name          = var.vpc_name
-  organization      = var.organization
+  #vpc_name          = var.vpc_name
+  #organization      = var.organization
 }
 

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = var.region
   default_tags {
     tags = local.default_tags
   }
@@ -28,25 +28,19 @@ provider "aws" {
 
 module "network" {
   source              = "./modules/network"
-  naming_prefix         = local.naming_prefix
-  #vpc_name            = var.vpc_name
+  naming_prefix       = local.naming_prefix
   public_subnet_cidrs = var.public_subnet_cidrs
   availability_zones  = var.availability_zones
   my_public_ip        = var.my_public_ip
-  #organization        = var.organization
 }
 
 module "instance" {
-  source            = "./modules/instance"
-  naming_prefix         = local.naming_prefix
-  #vpc_id            = module.network.vpc_id
-  subnet_id         = module.network.public_subnet_ids[0].id
+  source             = "./modules/instance"
+  naming_prefix      = local.naming_prefix
+  subnet_id          = module.network.public_subnet_ids[0].id
   security_groups_id = [module.network.security_group_id]
-  #key_name          = var.key_name
-  public_key        = var.public_key
-  ami               = var.ami
-  instance_type     = var.instance_type
-  #vpc_name          = var.vpc_name
-  #organization      = var.organization
+  public_key         = var.public_key
+  ami                = var.ami
+  instance_type      = var.instance_type
 }
 

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -5,20 +5,17 @@ locals {
 
 resource "aws_key_pair" "public_key" {
   public_key = var.public_key
-  #public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHtsDTrBlj5M+jg+vqFoK6oHnmtLrbXWViBZOhWo4kex mortzkeb@gmail.com"
 }
 
 
-resource "aws_instance" "ec2_instance_1" {
-  #ami           = "ami-08a6efd148b1f7504"  # Amazon Linux 2023 Kernel 6.1 64 bits
-  ami = var.ami
-  #instance_type = "t2.micro"
-  instance_type = var.instance_type
-  key_name = aws_key_pair.public_key.id
+resource "aws_instance" "ec2_instance" {
+  ami                         = var.ami
+  instance_type               = var.instance_type
+  key_name                    = aws_key_pair.public_key.id
   associate_public_ip_address = true
-  subnet_id = var.subnet_id
-  vpc_security_group_ids = var.security_groups_id
-  
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = var.security_groups_id
+
   tags = {
     Name = local.instance_name
   }

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -1,3 +1,8 @@
+locals {
+  instance_name = "${var.naming_prefix}-ec2-1"
+}
+
+
 resource "aws_key_pair" "public_key" {
   public_key = var.public_key
   #public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHtsDTrBlj5M+jg+vqFoK6oHnmtLrbXWViBZOhWo4kex mortzkeb@gmail.com"
@@ -12,9 +17,9 @@ resource "aws_instance" "ec2_instance_1" {
   key_name = aws_key_pair.public_key.id
   associate_public_ip_address = true
   subnet_id = var.subnet_id
-  vpc_security_group_ids = var.security_group_id
+  vpc_security_group_ids = var.security_groups_id
+  
   tags = {
-    Name = "ec2-instance-1_${var.vpc_name}"
-    Organization = var.organization
+    Name = local.instance_name
   }
 }

--- a/modules/instance/outputs.tf
+++ b/modules/instance/outputs.tf
@@ -1,4 +1,4 @@
 output "instance_public_ip" {
   description = "IP pública de la instancia EC2"
-  value = aws_instance.ec2_instance_1.public_ip
+  value       = aws_instance.ec2_instance.public_ip
 }

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -4,14 +4,14 @@ variable "naming_prefix" {
 }
 
 variable "public_key" {
-  description = "Contenido de la clave pública SSH"
+  description = "Clave pública SSH, solo se puede introducir un string de momento. Copiar el contenido de ~/.ssh/<key-name>.pub"
   type        = string
 }
 
 variable "ami" {
   description = "AMI de la instancia EC2"
   type        = string
-  default     = "ami-08a6efd148b1f7504"
+  default     = "ami-08a6efd148b1f7504" # Amazon Linux 2023 Kernel 6.1 64 bits
 }
 
 variable "instance_type" {

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -1,13 +1,7 @@
-variable "vpc_name" {
-  description = "Nombre de la VPC"
+variable "naming_prefix" {
+  description = "Prefijo base para el nombramiento de recursos"
   type        = string
 }
-
-variable "organization" {
-  type        = string
-  description = "Nombre de la organización"
-}
-
 
 variable "public_key" {
   description = "Contenido de la clave pública SSH"
@@ -31,8 +25,8 @@ variable "subnet_id" {
   type        = string
 }
 
-variable "security_group_id" {
-  description = "ID del security group"
+variable "security_groups_id" {
+  description = "ID de security groups"
   type        = list(string)
 }
 

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,9 +1,16 @@
+locals {
+  vpc         = "${var.naming_prefix}-vpc"
+  igw         = "${var.naming_prefix}-igw"
+  subnet_base = "${var.naming_prefix}-subnet-public"
+  rt_public = "${var.naming_prefix}-rt-public"
+  security_group = "${var.naming_prefix}-secgrp"
+}
+
+
 resource "aws_vpc" "main" {
   cidr_block = var.vpc_cidr_block
-
   tags = {
-    Name         = var.vpc_name
-    Organization = var.organization
+    Name         = local.vpc
   }
 }
 
@@ -14,8 +21,8 @@ resource "aws_subnet" "public_subnets" {
   availability_zone = var.availability_zones[count.index]
 
   tags = {
-    Name         = "public-subnet-${count.index + 1}_${var.availability_zones[count.index]}_${var.vpc_name}"
-    Organization = var.organization
+    Name = "${local.subnet_base}-${count.index + 1}"
+    #Name         = "public-subnet-${count.index + 1}_${var.availability_zones[count.index]}_${var.vpc_name}"
   }
 }
 
@@ -23,8 +30,7 @@ resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name         = "igw_${var.vpc_name}"
-    Organization = var.organization
+    Name         = local.igw
   }
 }
 
@@ -37,8 +43,7 @@ resource "aws_route_table" "public_routing_table" {
   }
 
   tags = {
-    Name         = "public-routing-table_${var.vpc_name}"
-    Organization = var.organization
+    Name         = local.rt_public
   }
 }
 
@@ -49,13 +54,12 @@ resource "aws_route_table_association" "public_subnet_association" {
 }
 
 resource "aws_security_group" "main" {
-  name        = "secgrp_${var.vpc_name}"
+  name        = local.security_group
   description = "Security rules for EC2 instance"
   vpc_id      = aws_vpc.main.id
 
   tags = {
-    Name         = "secgrp_${var.vpc_name}"
-    Organization = var.organization
+    Name         = local.security_group
   }
 }
 

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,8 +1,8 @@
 locals {
-  vpc         = "${var.naming_prefix}-vpc"
-  igw         = "${var.naming_prefix}-igw"
-  subnet_base = "${var.naming_prefix}-subnet-public"
-  rt_public = "${var.naming_prefix}-rt-public"
+  vpc            = "${var.naming_prefix}-vpc"
+  igw            = "${var.naming_prefix}-igw"
+  subnet_base    = "${var.naming_prefix}-subnet-public"
+  rt_public      = "${var.naming_prefix}-rt-public"
   security_group = "${var.naming_prefix}-secgrp"
 }
 
@@ -10,7 +10,7 @@ locals {
 resource "aws_vpc" "main" {
   cidr_block = var.vpc_cidr_block
   tags = {
-    Name         = local.vpc
+    Name = local.vpc
   }
 }
 
@@ -22,7 +22,6 @@ resource "aws_subnet" "public_subnets" {
 
   tags = {
     Name = "${local.subnet_base}-${count.index + 1}"
-    #Name         = "public-subnet-${count.index + 1}_${var.availability_zones[count.index]}_${var.vpc_name}"
   }
 }
 
@@ -30,7 +29,7 @@ resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name         = local.igw
+    Name = local.igw
   }
 }
 
@@ -43,7 +42,7 @@ resource "aws_route_table" "public_routing_table" {
   }
 
   tags = {
-    Name         = local.rt_public
+    Name = local.rt_public
   }
 }
 
@@ -59,7 +58,7 @@ resource "aws_security_group" "main" {
   vpc_id      = aws_vpc.main.id
 
   tags = {
-    Name         = local.security_group
+    Name = local.security_group
   }
 }
 

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,12 +1,12 @@
-variable "vpc_name" {
+variable "naming_prefix" {
+  description = "Prefijo base para el nombramiento de recursos"
   type        = string
-  description = "Nombre de la VPC"
 }
 
-variable "organization" {
-  type        = string
-  description = "Nombre de la organización"
-}
+#variable "vpc_name" {
+#  type        = string
+#  description = "Nombre de la VPC"
+#}
 
 variable "vpc_cidr_block" {
   type        = string

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -3,11 +3,6 @@ variable "naming_prefix" {
   type        = string
 }
 
-#variable "vpc_name" {
-#  type        = string
-#  description = "Nombre de la VPC"
-#}
-
 variable "vpc_cidr_block" {
   type        = string
   default     = "10.0.0.0/16"

--- a/variables.tf
+++ b/variables.tf
@@ -19,9 +19,6 @@ variable "region" {
   description = "Región de AWS"
 }
 
-#variable "vpc_name" {
-#  type    = string
-#}
 
 variable "public_subnet_cidrs" {
   type    = list(string)
@@ -34,7 +31,7 @@ variable "availability_zones" {
 }
 
 variable "my_public_ip" {
-  type    = string
+  type = string
 }
 
 variable "organization" {
@@ -42,10 +39,6 @@ variable "organization" {
   default = "Mikroways"
 }
 
-#variable "key_name" {
-#  type    = string
-#  default = "mcanaza-public-key"
-#}
 
 variable "public_key" {
   type    = string
@@ -62,7 +55,6 @@ variable "instance_type" {
   default = "t2.micro"
 }
 
-# outputs.tf (root)
 output "vpc_id" {
   value = module.network.vpc_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,27 @@
-variable "vpc_name" {
-  type    = string
+
+variable "prefix" {
+  type        = string
+  description = "Abreviatura de la organización o prefijo general para nombres"
 }
+
+variable "project" {
+  type        = string
+  description = "Nombre del proyecto"
+}
+
+variable "environment" {
+  type        = string
+  description = "Ambiente de despliegue"
+}
+
+variable "region" {
+  type        = string
+  description = "Región de AWS"
+}
+
+#variable "vpc_name" {
+#  type    = string
+#}
 
 variable "public_subnet_cidrs" {
   type    = list(string)


### PR DESCRIPTION
Se realiza el reordamiento para el nombramiento de recursos, haciendo uso de locals y variables para que los modulos puedan heredar el mismo esquema en el nombramiento de recursos.

En caso de que el nombramiento no sea convincente solo deberia ser necesario modificar:

```
  naming_prefix = "${var.prefix}-${var.project}-${var.environment}-${var.region}"
```

En el `root` module y adaptarlo según la necesidad especifica. 

Esto surge a modo de seguir las prácticas recomendadas de Stepan Stipi en su post llamado [Cloud Naming Convention](https://web.archive.org/web/20250102150056/https://stepan.wtf/cloud-naming-convention/)


El nombramineto actual por supuesto que esta sujeto a cambios. 